### PR TITLE
fix: CD가 실패하는 문제

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,17 +56,21 @@ jobs:
             echo "이미지명: ${DOCKER_USERNAME}/${DOCKER_IMAGE_NODE}"
 
             echo "Running new node container"
-            sudo docker run -d -p ${NODE_PORT}:8081 --name medicare-node \
-            -e OPENAI_API_KEY=${OPENAI_API_KEY} \
-            -e PUBLIC_URL=${PUBLIC_URL} \
-            -e WEBHOOK_URL=${WEBHOOK_URL} \
-            -e TWILIO_ACCOUNT_SID=${TWILIO_ACCOUNT_SID} \
-            -e TWILIO_AUTH_TOKEN=${TWILIO_AUTH_TOKEN} \
-            -e TWILIO_CALLER_NUMBER=${TWILIO_CALLER_NUMBER} \
-            -e TWILIO_RECIPIENT_NUMBER=${TWILIO_RECIPIENT_NUMBER} \
-            -e REDIS_HOST=${REDIS_HOST} \
-            -e REDIS_PORT=${REDIS_PORT} \
-            ${DOCKER_USERNAME}/${DOCKER_IMAGE_NODE}
+            sudo docker run -d -p "${NODE_PORT}:8081" --name medicare-node \
+            -e OPENAI_API_KEY="${OPENAI_API_KEY}" \
+            -e PUBLIC_URL="${PUBLIC_URL}" \
+            -e WEBHOOK_URL="${WEBHOOK_URL}" \
+            -e TWILIO_ACCOUNT_SID="${TWILIO_ACCOUNT_SID}" \
+            -e TWILIO_AUTH_TOKEN="${TWILIO_AUTH_TOKEN}" \
+            -e TWILIO_CALLER_NUMBER="${TWILIO_CALLER_NUMBER}" \
+            -e TWILIO_RECIPIENT_NUMBER="${TWILIO_RECIPIENT_NUMBER}" \
+            -e REDIS_HOST="${REDIS_HOST}" \
+            -e REDIS_PORT="${REDIS_PORT}" \
+            "${DOCKER_USERNAME}/${DOCKER_IMAGE_NODE}"
+
+            # 컨테이너 실행 확인
+            echo "컨테이너 실행 상태 확인:"
+            sudo docker ps -a | grep medicare-node
 
             echo "Cleaning up old images"
             sudo docker image prune -f


### PR DESCRIPTION
### 배경
- 작업 이후 Github Action에 의해 도커 컨테이너가 원격 서버에서 실행되어야 하나, 실행이 되지 않는 문제를 확인.
- 도커 컨테이너가 실행되었다가 죽은것이 아닌, 실행이 되지 않는 문제로 최종 확인함
  - `docker ps -a`에서 확인되는 바가 없음
- 배포 프로세스 도중의 로그에서 원인으로 의심되는 부분을 확인
```
docker: invalid reference format.
See 'docker run --help'.
```

### Description
- GitHub Secrets에 따옴표, 공백, 특수문자가 포함된 값을 사용할 경우, 따옴표로 외부를 감싸주지 않으면, Docker에서 명령어를 파싱하는 과정에서 오류가 발생한다
- 오류가 발생하지 않도록, 환경 변수를 주입하는 부분을 따옴표로 감싸 workflow를 재구성