### PR TITLE
chore: TWILIO_CALLER_NUMBERS 오타 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
             WEBHOOK_URL="${{ secrets.WEBHOOK_URL }}"
             TWILIO_ACCOUNT_SID="${{ secrets.TWILIO_ACCOUNT_SID }}"
             TWILIO_AUTH_TOKEN="${{ secrets.TWILIO_AUTH_TOKEN }}"
-            TWILIO_CALLER_NUMBER="${{ secrets.TWILIO_CALLER_NUMBER }}"
+            TWILIO_CALLER_NUMBERS="${{ secrets.TWILIO_CALLER_NUMBERS }}"
             TWILIO_RECIPIENT_NUMBER="${{ secrets.TWILIO_RECIPIENT_NUMBER }}"
             REDIS_HOST="${{ secrets.REDIS_HOST }}"
             REDIS_PORT="${{ secrets.REDIS_PORT }}"
@@ -62,7 +62,7 @@ jobs:
             -e WEBHOOK_URL="${WEBHOOK_URL}" \
             -e TWILIO_ACCOUNT_SID="${TWILIO_ACCOUNT_SID}" \
             -e TWILIO_AUTH_TOKEN="${TWILIO_AUTH_TOKEN}" \
-            -e TWILIO_CALLER_NUMBER="${TWILIO_CALLER_NUMBER}" \
+            -e TWILIO_CALLER_NUMBERS="${TWILIO_CALLER_NUMBERS}" \
             -e TWILIO_RECIPIENT_NUMBER="${TWILIO_RECIPIENT_NUMBER}" \
             -e REDIS_HOST="${REDIS_HOST}" \
             -e REDIS_PORT="${REDIS_PORT}" \

--- a/websocket-server/dist/server.js
+++ b/websocket-server/dist/server.js
@@ -35,7 +35,7 @@ const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
 const WEBHOOK_URL = process.env.WEBHOOK_URL || "";
 const TWILIO_ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID;
 const TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN;
-const TWILIO_CALLER_NUMBER = process.env.TWILIO_CALLER_NUMBER;
+const TWILIO_CALLER_NUMBERS = process.env.TWILIO_CALLER_NUMBERS;
 const TWILIO_RECIPIENT_NUMBER = process.env.TWILIO_RECIPIENT_NUMBER;
 const twilioClient = (0, twilio_1.default)(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
 if (!OPENAI_API_KEY) {
@@ -86,7 +86,7 @@ mainRouter.post("/call", (req, res) => __awaiter(void 0, void 0, void 0, functio
         const call = yield twilioClient.calls.create({
             url: twimlUrl.toString(),
             to: phoneNumber || TWILIO_RECIPIENT_NUMBER,
-            from: TWILIO_CALLER_NUMBER,
+            from: TWILIO_CALLER_NUMBERS,
         });
         logger.info(`전화 연결 시작 - CallSid: ${call.sid}, elderId: ${elderId}`);
         res.json({ success: true, sid: call.sid, elderId, prompt: prompt || null });


### PR DESCRIPTION
twilio caller number이 여러개가 되면서 
`TWILIO_CALLER_NUMBER` > `TWILIO_CALLER_NUMBERS` 로 변수명이 바뀌었지만 적용되지 않은 부분을 발견하여 수정