### PR TITLE
Feat/process no answer call

### DIFF
--- a/websocket-server/src/server.ts
+++ b/websocket-server/src/server.ts
@@ -182,6 +182,9 @@ mainRouter.post('/run', async (req: Request, res: Response) => {
 
         const call = await twilioClient.calls.create({
             url: twimlUrl.toString(),
+            statusCallback: `${PUBLIC_URL}/call/status-callback`,
+            // statusCallbackEvent: ['no-answer', 'answered'],
+            statusCallbackMethod: 'POST',
             method: 'POST',
             to: phoneNumber,
             from: availableCallerNumber,
@@ -215,6 +218,23 @@ mainRouter.post('/run', async (req: Request, res: Response) => {
         logger.error('전화 실패:', err);
         res.status(500).json({ success: false, error: String(err) });
     }
+});
+// Express.js 예시
+mainRouter.post('/status-callback', (req, res) => {
+    const { CallSid, CallStatus, CallDuration, From, To } = req.body;
+    console.log('콜백 url 도착');
+
+    console.log(`Call ${CallSid} ended with status: ${CallStatus}`);
+
+    if (CallStatus === 'no-answer') {
+        console.log(`부재중 전화: ${From} → ${To}`);
+        // 부재중 처리 로직
+        // 예: 데이터베이스에 저장, 알림 발송 등
+    } else if (CallStatus === 'in-progress') {
+        console.log('전화 연결');
+    }
+
+    res.status(200).send('OK');
 });
 
 app.use('/call', mainRouter);

--- a/websocket-server/src/sessionManager.ts
+++ b/websocket-server/src/sessionManager.ts
@@ -173,7 +173,7 @@ function connectToOpenAI(sessionId: string): void {
                     silence_duration_ms: 300,
                 },
                 voice: 'ash',
-                input_audio_transcription: { model: 'whisper-1' },
+                input_audio_transcription: { model: 'gpt-4o-realtime-preview' },
                 input_audio_format: 'g711_ulaw',
                 output_audio_format: 'g711_ulaw',
                 input_audio_noise_reduction: { type: 'near_field' },


### PR DESCRIPTION
### Desc
- twilio에서 전화 상태값 확인 
  - 전화가 끝나면 `/status-callback` 엔드포인트로 전화의 status를 반환
  - status 종류: completed (완료), busy (통화 중), no-answer (부재중), canceled (취소: 발신자 측에서 취소. 즉 전화가 걸리고 있는데 서버가 다운된 상황 등), failed (실패: 기술적인 문제로 통화 연결 실패) 
  - twilio에서 던져 주는 5개의 status 를 스프링 서버 컬럼값에 맞게 매핑
```javascript
const mapping: { [key: string]: string } = {
        completed: 'completed',
        busy: 'busy',
        'no-answer': 'no-answer',
        canceled: 'failed', // 'canceled'는 'failed'로 매핑
        failed: 'failed',
    };
```
<img width="1199" height="95" alt="image" src="https://github.com/user-attachments/assets/70042f52-3fe8-4955-a695-838decaaf9b8" />

- twilio console > Phone Numbers > Active numbers > 번호 선택 > Call status changes 에서 callStatus를 받을 url 설정 필요
  - 현재는 로컬 테스트를 위해 ngrok 으로 설정함. 배포 후 수정 필요 
<img width="520" height="154" alt="image" src="https://github.com/user-attachments/assets/d7321aa3-abb7-4023-afe8-c360ea90317e" />

- completed, no-answer 데이터 저장 확인 완료 
  - 현재는 부재중 케어콜만 다루기 때문에 2가지 상태값을 위주로 확인
  - 혼자서 테스트 하느라 busy도 테스트 실패.. 

### 추가 설명
```typescript
 const call = await twilioClient.calls.create({
          url: twimlUrl.toString(),
          statusCallback: `${PUBLIC_URL}/call/status-callback`,
          statusCallbackEvent: ['initiated', 'ringing', 'answered', 'completed'],
          statusCallbackMethod: 'POST',
          method: 'POST',
          to: phoneNumber,
          from: availableCallerNumber,
          timeout: 30,
      });
```
여기서 `timeout` 값이 "신호가 걸리는 시간(초)" 을 뜻함. twilio 특성 상 +5초 정도된다고 함
- twilio는 해당 시간이 끝날 때까지 신호를 보냄
  - 여기서 문제가 ""수신자가 전화를 끊어도"" timeout이 끝나기 전에는 신호를 보내게 됨
  - 막으려고 나름 많이 찾아봤는데 통신사에서 실시간으로 수신자가 전화를 끝었다는 메시지를 주지 않아서 다루기 힘들다는 얘기만 있었음
  - 테스트 결과 timeout값을 15초로 설정했더니 전화를 끊었을 때 다시 걸지 않음 (다시 걸기 전에 timeout이 완료되는 것)
  - 로직으로 우회하려고 지속적으로 시도하다가 실패해서 구현 완료된 부분만 먼저 Pr올립니다.
- 따라서 현재는 timeout이 끝날 때까지 전화를 받지 않으면 (아예 받지 않거나, 계속 끊거나) no-answer값으로 call status가 저장됨
 
