### PR TITLE
hotfix: 케어콜 음성 Threshold값 수정

### DIFF
--- a/websocket-server/src/sessionManager.ts
+++ b/websocket-server/src/sessionManager.ts
@@ -159,7 +159,7 @@ function connectToOpenAI(sessionId: string): void {
                 modalities: ['text', 'audio'],
                 turn_detection: {
                     type: 'server_vad',
-                    threshold: 1.0,
+                    threshold: 0.85,
                     prefix_padding_ms: 1200,
                     silence_duration_ms: 700,
                 },


### PR DESCRIPTION
### Desc
- 음성 데이터의 과도한 Thresholding으로 AI가 음성을 잘 알아듣지 못해 값을 조정 처리함